### PR TITLE
Fixed up BObjectList compilation failures

### DIFF
--- a/source/FSUtils.h
+++ b/source/FSUtils.h
@@ -155,7 +155,7 @@ status_t FSDeleteFolder(BEntry *, CopyLoopControl *, bool updateStatus,
 status_t FSCopyAttributesAndStats(BNode *, BNode *);
 
 void FSDuplicate(BObjectList<entry_ref> *srcList, BList *pointList);
-void FSMoveToFolder(BObjectList<entry_ref> *srcList, BEntry *, uint32 moveMode,
+void FSMoveToFolder(BObjectList<entry_ref, true> *srcList, BEntry *, uint32 moveMode,
 	BList *pointList = NULL);
 void FSMakeOriginalName(char *name, BDirectory *destDir, const char *suffix);
 bool FSIsTrashDir(const BEntry *);
@@ -164,7 +164,7 @@ bool FSIsDeskDir(const BEntry *);
 bool FSIsSystemDir(const BEntry *);
 bool FSIsBeOSDir(const BEntry *);
 bool FSIsHomeDir(const BEntry *);
-void FSMoveToTrash(BObjectList<entry_ref> *srcList, BList *pointList = NULL,
+void FSMoveToTrash(BObjectList<entry_ref, true> *srcList, BList *pointList = NULL,
 	bool asynch = true);
 	// Deprecated
 	// only returns actual result if asynch false

--- a/source/InnerPanelIcons.cpp
+++ b/source/InnerPanelIcons.cpp
@@ -530,7 +530,7 @@ status_t TTrackerIcon::DroppedSomething( const BMessage *message )
 		BEntry entry( &fRef, true );
 		if ( entry.IsDirectory() )
 		{
-			BObjectList<entry_ref> *list = new BObjectList<entry_ref>();
+			BObjectList<entry_ref, true> *list = new BObjectList<entry_ref, true>();
 			entry_ref ref;
 			int i;
 			for ( i=0; ; i++ )
@@ -1506,7 +1506,7 @@ status_t TTrashIcon::DroppedSomething( const BMessage *message )
 {
 	if ( message->what == B_SIMPLE_DATA )
 	{
-		BObjectList<entry_ref> *list = new BObjectList<entry_ref>();
+		BObjectList<entry_ref, true> *list = new BObjectList<entry_ref, true>();
 		entry_ref ref;
 		int i;
 		for ( i=0; ; i++ )

--- a/source/LockingList2.h
+++ b/source/LockingList2.h
@@ -8,10 +8,10 @@
 
 namespace BPrivate {
 
-template <class T>
-class LockingList2 : public BObjectList<T> {
+template <class T, bool Owning = false>
+class LockingList2 : public BObjectList<T, Owning> {
 public:
-	LockingList2(int32 itemsPerBlock = 20, bool owning = false);
+	LockingList2(int32 itemsPerBlock = 20);
 	~LockingList2()
 		{
 		Lock();
@@ -24,29 +24,29 @@ public:
 	BLocker lock;
 };
 
-template<class T>
-LockingList2<T>::LockingList2(int32 itemsPerBlock, bool owning)
-	:	BObjectList<T>(itemsPerBlock, owning)
+template<class T, bool O>
+LockingList2<T, O>::LockingList2(int32 itemsPerBlock)
+	:	BObjectList<T, O>(itemsPerBlock)
 {
 }
 
-template<class T>
+template<class T, bool O>
 bool 
-LockingList2<T>::Lock()
+LockingList2<T, O>::Lock()
 {
 	return lock.Lock();
 }
 
-template<class T>
+template<class T, bool O>
 void 
-LockingList2<T>::Unlock()
+LockingList2<T, O>::Unlock()
 {
 	lock.Unlock();
 }
 
-template<class T>
+template<class T, bool O>
 bool 
-LockingList2<T>::IsLocked() const
+LockingList2<T, O>::IsLocked() const
 {
 	return lock.IsLocked();
 }

--- a/source/NavMenu.h
+++ b/source/NavMenu.h
@@ -46,7 +46,7 @@ All rights reserved.
 #include "SlowMenu.h"
 
 
-template<class T> class BObjectList;
+template<class T, bool O> class BObjectList;
 class BMenuItem;
 
 namespace BPrivate {
@@ -75,9 +75,9 @@ class TrackingHookData {
 class BNavMenu : public BSlowMenu {
 	public:
 		BNavMenu(const char* title, uint32 message, const BHandler *,
-			BWindow *parentWindow = NULL, const BObjectList<BString> *list = NULL);
+			BWindow* parentWindow = NULL, const BStringList* list = NULL);
 		BNavMenu(const char* title, uint32 message, const BMessenger &,
-			BWindow *parentWindow = NULL, const BObjectList<BString> *list = NULL);
+			BWindow* parentWindow = NULL, const BStringList* list = NULL);
 			// parentWindow, if specified, will be closed if nav menu item invoked
 			// with option held down
 							
@@ -95,8 +95,8 @@ class BNavMenu : public BSlowMenu {
 		void SetTarget(const BMessenger &);
 		BMessenger Target();
 
-		void SetTypesList(const BObjectList<BString> *list);
-		const BObjectList<BString> *TypesList() const;	
+		void SetTypesList(const BStringList* list);
+		const BStringList* TypesList() const;
 
 		void AddNavDir(const Model *model, uint32 what, BHandler *target,
 			bool populateSubmenu);
@@ -110,10 +110,10 @@ class BNavMenu : public BSlowMenu {
 		static int CompareFolderNamesFirstOne(const BMenuItem *, const BMenuItem *);
 		static int CompareOne(const BMenuItem *, const BMenuItem *);
 
-		static ModelMenuItem *NewModelItem(Model *, const BMessage *, const BMessenger &,
-			bool suppressFolderHierarchy=false, BContainerWindow * = NULL,
-			const BObjectList<BString> *typeslist = NULL,
-			TrackingHookData *hook = NULL);
+		static ModelMenuItem* NewModelItem(Model*, const BMessage*,
+		        const BMessenger&, bool suppressFolderHierarchy = false,
+		        BContainerWindow* = NULL, const BStringList* typeslist = NULL,
+		        TrackingHookData* hook = NULL);
 
 		TrackingHookData *InitTrackingHook(bool (*hookfunction)(BMenu *, void *),
 			const BMessenger *target, const BMessage *dragMessage);
@@ -137,11 +137,11 @@ class BNavMenu : public BSlowMenu {
 
 		// menu building state
 		uint8		fFlags;
-		BObjectList<BMenuItem> *fItemList;
+		BObjectList<BMenuItem, false>* fItemList;
 		EntryListBase *fContainer;
 		bool		fIteratingDesktop;
 
-		const BObjectList<BString> *fTypesList;
+		BStringList* fTypesList;
 
 		TrackingHookData fTrackingHook;
 };
@@ -154,11 +154,11 @@ class BNavMenu : public BSlowMenu {
 bool SpringLoadedFolderCompareMessages(const BMessage *incoming,
 	const BMessage *dragmessage);
 void SpringLoadedFolderSetMenuStates(const BMenu *menu,
-	const BObjectList<BString> *typeslist);
+	const BStringList *typeslist);
 void SpringLoadedFolderAddUniqueTypeToList(entry_ref *ref,
-	BObjectList<BString> *typeslist);
+	BStringList *typeslist);
 void SpringLoadedFolderCacheDragData(const BMessage *incoming,
-	BMessage **, BObjectList<BString> **typeslist);
+	BMessage **, BStringList **typeslist);
 
 } // namespace BPrivate
 


### PR DESCRIPTION
Modified BObjectList calls/definitions by backporting changes from Haiku Tracker sources.

Resolves #29 - following @waddlesplash comments, I reviewed the changes made to Haiku sources in https://github.com/haiku/haiku/commit/cbfbbf6d4d0e9c28332e8c1f53bf7134896ac7d3 and backported the changes. Now DockBert compiles and runs again on my system running latest nightly build. I suspect some of these files could do with being properly synced up with the upstream changes, but it all works again now :) 